### PR TITLE
feat: add skeleton tos screen

### DIFF
--- a/lib/screens/pre_user_creator.dart
+++ b/lib/screens/pre_user_creator.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/cupertino.dart';
+
+class PreUserCreatorScreen extends StatelessWidget {
+  const PreUserCreatorScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Placeholder();
+  }
+}

--- a/lib/screens/terms_of_use.dart
+++ b/lib/screens/terms_of_use.dart
@@ -1,3 +1,4 @@
+import 'package:ergo4all/screens/pre_user_creator.dart';
 import 'package:flutter/material.dart';
 
 const tosText =
@@ -21,6 +22,13 @@ class _TermsOfUseScreenState extends State<TermsOfUseScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final navigator = Navigator.of(context);
+
+    void navigateToPreUserCreation() {
+      navigator.pushReplacement(
+          MaterialPageRoute(builder: (_) => const PreUserCreatorScreen()));
+    }
+
     return Scaffold(
       appBar: AppBar(
         title: const Text("Terms of use"),
@@ -34,9 +42,11 @@ class _TermsOfUseScreenState extends State<TermsOfUseScreen> {
               children: [
                 const Text("I accept"),
                 Checkbox(
+                    key: const Key("accept-check"),
                     value: hasAccepted,
                     onChanged: (isChecked) {
                       toggleHasAccepted();
+                      if (isChecked!) navigateToPreUserCreation();
                     }),
               ],
             )

--- a/test/screens/terms_of_use_test.dart
+++ b/test/screens/terms_of_use_test.dart
@@ -1,0 +1,15 @@
+import 'package:ergo4all/screens/pre_user_creator.dart';
+import 'package:ergo4all/screens/terms_of_use.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets("should navigate to next screen once accepted", (tester) async {
+    await tester.pumpWidget(const MaterialApp(home: TermsOfUseScreen()));
+
+    await tester.tap(find.byKey(const Key("accept-check")));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(PreUserCreatorScreen), findsOneWidget);
+  });
+}


### PR DESCRIPTION
For now only contains placeholder text. Checking the accept checkbox navigates to the next screen.