### PR TITLE
feat: add logic to allow the user to click on each puppet body part 

### DIFF
--- a/apps/ergo4all/lib/results/overview/body_score_display.dart
+++ b/apps/ergo4all/lib/results/overview/body_score_display.dart
@@ -1,5 +1,6 @@
 import 'package:ergo4all/common/utils.dart';
 import 'package:ergo4all/results/common.dart';
+import 'package:ergo4all/results/overview/transparent_image_stack.dart';
 import 'package:flutter/material.dart';
 import 'package:rula/rula.dart';
 
@@ -24,11 +25,9 @@ enum _PartColor {
   yellow;
 }
 
-Widget _getBodyPartImage(BodyPart bodyPart, _PartColor color) {
+String _getAssetPathForPart(BodyPart bodyPart, _PartColor color) {
   final fileName = _fileNameForPart(bodyPart);
-  return Image.asset(
-    'assets/images/puppet/${fileName}_${color.name}.png',
-  );
+  return 'assets/images/puppet/${fileName}_${color.name}.png';
 }
 
 const _bodyPartsInDisplayOrder = [
@@ -82,16 +81,18 @@ class BodyScoreDisplay extends StatelessWidget {
       };
     }
 
-    return Stack(
-      children: _bodyPartsInDisplayOrder.map((part) {
-        final color = getColorForPart(part);
-        return GestureDetector(
-          onTap: () {
-            onBodyPartTapped?.call(part);
-          },
-          child: _getBodyPartImage(part, color),
-        );
-      }).toList(),
+    final bodyPartsCallbacks = _bodyPartsInDisplayOrder.map((part) {
+      return () => onBodyPartTapped?.call(part);
+    }).toList();
+
+    final bodyPartsImagePaths = _bodyPartsInDisplayOrder.map((part) {
+      final color = getColorForPart(part);
+      return _getAssetPathForPart(part, color);
+    }).toList();
+
+    return TransparentImageStack(
+      imagePaths: bodyPartsImagePaths,
+      onTaps: bodyPartsCallbacks,
     );
   }
 }

--- a/apps/ergo4all/lib/results/overview/transparent_image_stack.dart
+++ b/apps/ergo4all/lib/results/overview/transparent_image_stack.dart
@@ -1,0 +1,97 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:image/image.dart' as img;
+
+/// A stack of images with transparent parts. The difference to a regular
+/// [Stack] of [Image] is that this widget does transparency-respecting
+/// hit testing, ie. only opaque parts of the image are tappable.
+class TransparentImageStack extends StatefulWidget {
+  ///
+  const TransparentImageStack({
+    required this.imagePaths,
+    required this.onTaps,
+    super.key,
+  });
+
+  /// List of paths of the images to display.
+  final List<String> imagePaths;
+
+  /// List of callbacks for when images are tapped. These are analogous
+  /// to the [imagePaths] list.
+  final List<VoidCallback> onTaps;
+
+  @override
+  State<TransparentImageStack> createState() => _TransparentImageStackState();
+}
+
+class _TransparentImageStackState extends State<TransparentImageStack> {
+  final List<img.Image?> _decodedImages = [];
+  final List<GlobalKey> _imageKeys = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _loadAllImages();
+    _imageKeys
+        .addAll(List.generate(widget.imagePaths.length, (_) => GlobalKey()));
+  }
+
+  Future<void> _loadAllImages() async {
+    for (final path in widget.imagePaths) {
+      final bytes = await rootBundle.load(path);
+      final list = bytes.buffer.asUint8List();
+      final decoded = await compute(_decodeImage, list);
+      _decodedImages.add(decoded);
+    }
+    setState(() {}); // Ensure images are shown
+  }
+
+  static img.Image? _decodeImage(Uint8List data) {
+    return img.decodePng(data);
+  }
+
+  void _handleTap(TapDownDetails details) {
+    for (var i = _imageKeys.length - 1; i >= 0; i--) {
+      final key = _imageKeys[i];
+      final decoded = _decodedImages[i];
+      if (decoded == null) continue;
+
+      final ctx = key.currentContext;
+      if (ctx == null) continue;
+
+      final box = ctx.findRenderObject()! as RenderBox;
+      final localPos = box.globalToLocal(details.globalPosition);
+      final size = box.size;
+
+      final dx = (localPos.dx * decoded.width / size.width).toInt();
+      final dy = (localPos.dy * decoded.height / size.height).toInt();
+
+      if (dx >= 0 && dx < decoded.width && dy >= 0 && dy < decoded.height) {
+        final pixel = decoded.getPixelSafe(dx, dy);
+        final alpha = pixel.a;
+        if (alpha > 10) {
+          widget.onTaps[i](); // Found opaque pixel
+          break;
+        }
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      behavior: HitTestBehavior.translucent,
+      onTapDown: _handleTap,
+      child: Stack(
+        children: List.generate(widget.imagePaths.length, (index) {
+          return Image.asset(
+            widget.imagePaths[index],
+            key: _imageKeys[index],
+            fit: BoxFit.contain,
+          );
+        }),
+      ),
+    );
+  }
+}

--- a/apps/ergo4all/pubspec.yaml
+++ b/apps/ergo4all/pubspec.yaml
@@ -46,6 +46,7 @@ dependencies:
   flutter_svg: ^2.0.17
   path: ^1.9.1
   svg_flutter: ^0.0.1
+  image: ^4.1.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
logic added to allow the user to click on each puppet body part  and being redirect to the bodypart details screen. it works by checking if the pixels the user clicked on are opaque or not in the image on top, if they are not opaque checks the same for all the following images until it finds the body part the user was clicking on. 

[recording.webm](https://github.com/user-attachments/assets/98b5a487-ce96-4e4f-98ad-3cc86f9c40e2)
