### PR TITLE
feat: continuous heatmap

### DIFF
--- a/apps/ergo4all/lib/common/rula_color.dart
+++ b/apps/ergo4all/lib/common/rula_color.dart
@@ -1,3 +1,4 @@
+import 'package:common/math_utils.dart';
 import 'package:fast_immutable_collections/fast_immutable_collections.dart';
 import 'package:flutter/material.dart';
 
@@ -15,14 +16,39 @@ abstract final class RulaColor {
 
   static const _high = Color(0xFFFF5A5F);
 
-  /// Gets the color for a normalized score.
-  static Color forScore(double score, {bool dark = false}) => switch (score) {
+  /// Gets the discrete color for a normalized score.
+  static Color discreteForScore(double score, {bool dark = false}) =>
+      switch (score) {
         < 0.20 => _low,
         <= 0.40 => dark ? _lowMidDark : _lowMid,
         <= 0.60 => _mid,
         <= 0.80 => _midHigh,
         _ => _high
       };
+
+  /// Gets the continuous color for a normalized score.
+  /// The score is intended to be in the range [0; 1].
+  static Color continuousForScore(double normalizedScore, {bool dark = false}) {
+    final lowMid = dark ? _lowMidDark : _lowMid;
+    return switch (normalizedScore) {
+      < 0.25 => Color.lerp(_low, lowMid, invLerp(0, 0.25, normalizedScore))!,
+      <= 0.50 => Color.lerp(
+          _lowMid,
+          _mid,
+          invLerp(0.25, 0.5, normalizedScore),
+        )!,
+      <= 0.75 => Color.lerp(
+          _mid,
+          _midHigh,
+          invLerp(0.5, 0.75, normalizedScore),
+        )!,
+      _ => Color.lerp(
+          _midHigh,
+          _high,
+          invLerp(0.75, 1, normalizedScore),
+        )!
+    };
+  }
 
   /// All Rula score colors from low -> high.
   static const IList<Color> all =

--- a/apps/ergo4all/lib/home/puppet_graphic.dart
+++ b/apps/ergo4all/lib/home/puppet_graphic.dart
@@ -27,7 +27,7 @@ class PuppetGraphic extends StatelessWidget {
           padding: const EdgeInsets.all(30),
           child: Image.asset(
             'assets/images/puppet/full_body.png',
-            color: RulaColor.forScore(0),
+            color: RulaColor.discreteForScore(0),
             fit: BoxFit.contain,
             colorBlendMode: BlendMode.modulate,
           ),

--- a/apps/ergo4all/lib/results/body_part_detail/body_part_line_chart.dart
+++ b/apps/ergo4all/lib/results/body_part_detail/body_part_line_chart.dart
@@ -58,8 +58,8 @@ class _BodyPartLineChartState extends State<BodyPartLineChart> {
         .mapWithIndex((IList<double> timeline, int timelineIndex) {
       final isSelectedTimeline = timelineIndex == highlightedTimelineIndex;
 
-      final rulaColors =
-          timeline.map((score) => RulaColor.forScore(score, dark: true));
+      final rulaColors = timeline
+          .map((score) => RulaColor.discreteForScore(score, dark: true));
 
       final colors = isSelectedTimeline
           ? rulaColors.toList()

--- a/apps/ergo4all/lib/results/detail/heatmap_painter.dart
+++ b/apps/ergo4all/lib/results/detail/heatmap_painter.dart
@@ -21,7 +21,7 @@ class HeatmapPainter extends CustomPainter {
 
     for (var i = 0; i < normalizedScores.length; i++) {
       final value = normalizedScores[i];
-      paint.color = RulaColor.forScore(value);
+      paint.color = RulaColor.continuousForScore(value);
 
       canvas.drawRect(
         Rect.fromLTWH(i * cellWidth, 0, cellWidth, size.height),

--- a/apps/ergo4all/lib/results/overview/body_score_display.dart
+++ b/apps/ergo4all/lib/results/overview/body_score_display.dart
@@ -76,7 +76,7 @@ class BodyScoreDisplay extends StatelessWidget {
 
     final colors = _bodyPartsInDisplayOrder.map((part) {
       final score = getNormalizedScoreForPart(part);
-      return RulaColor.forScore(score);
+      return RulaColor.discreteForScore(score);
     }).toList();
 
     return TransparentImageStack(


### PR DESCRIPTION
We now have a function for calculating continuous colors for rula scores and we use it for the heat maps on the result detail screen.

Resolves #100