### PR TITLE
fix: layout problems on analysis screen

### DIFF
--- a/apps/ergo4all/lib/analysis/screen.dart
+++ b/apps/ergo4all/lib/analysis/screen.dart
@@ -266,24 +266,26 @@ class _LiveAnalysisScreenState extends State<LiveAnalysisScreen>
 
     return Scaffold(
       backgroundColor: woodSmoke,
-      body: SizedBox.expand(
+      body: SafeArea(
         child: Column(
           children: [
-            Expanded(child: Container()),
-            Stack(
-              children: [
-                cameraPreview,
-                Positioned(
-                  bottom: largeSpace,
-                  left: largeSpace,
-                  right: largeSpace,
-                  child: RecordingProgressIndicator(
-                    remainingTime: progressAnimationController.value,
-                    criticalTime: 5,
-                    initialTime: 30,
+            Expanded(
+              child: Stack(
+                alignment: Alignment.center,
+                children: [
+                  cameraPreview,
+                  Positioned(
+                    left: largeSpace,
+                    right: largeSpace,
+                    bottom: largeSpace,
+                    child: RecordingProgressIndicator(
+                      remainingTime: progressAnimationController.value,
+                      criticalTime: 5,
+                      initialTime: 30,
+                    ),
                   ),
-                ),
-              ],
+                ],
+              ),
             ),
             const SizedBox(height: smallSpace),
             Center(
@@ -299,7 +301,6 @@ class _LiveAnalysisScreenState extends State<LiveAnalysisScreen>
                 child: Text(isRecording ? 'Stop' : 'Start'),
               ),
             ),
-            const SizedBox(height: mediumSpace),
           ],
         ),
       ),


### PR DESCRIPTION
The camera preview widget would currently take up as much space as possible. This was fine for phones where the camera image aspect ratio clamped it into a sensible size. But on tablet, where the image aspect was taller it would take up more of the total screen space.

Fixed by making sure that the camera preview may only take up the space that is left over after the bottom button has been placed.

Resolves #111