### PR TITLE
feat: clear onboarding state

### DIFF
--- a/apps/ergo4all/lib/onboarding/state.dart
+++ b/apps/ergo4all/lib/onboarding/state.dart
@@ -5,9 +5,11 @@ abstract class OnboardingState {
   /// Checks whether onboarding was completed.
   Future<bool> isCompleted();
 
-  /// Sets the onboarding to be completed. There is currently no API
-  /// for 'un-completing' the onboarding.
+  /// Sets the onboarding to be completed.
   Future<void> setCompleted();
+
+  /// Reset the onboarding state to un-completed.
+  Future<void> reset();
 }
 
 /// Implementation of [OnboardingState] which stores the completion state
@@ -28,5 +30,10 @@ class PrefsOnboardingState implements OnboardingState {
   @override
   Future<void> setCompleted() async {
     await _prefs.setBool(_key, true);
+  }
+
+  @override
+  Future<void> reset() async {
+    await _prefs.clear(allowList: {_key});
   }
 }

--- a/apps/ergo4all/lib/welcome/screen.dart
+++ b/apps/ergo4all/lib/welcome/screen.dart
@@ -38,6 +38,7 @@ class _WelcomeScreenState extends State<WelcomeScreen> {
   late final OnboardingState onboardingState;
 
   Option<String> projectVersion = none();
+  int tapCount = 0;
 
   Future<void> loadProjectVersion() async {
     final info = await PackageInfo.fromPlatform();
@@ -53,6 +54,27 @@ class _WelcomeScreenState extends State<WelcomeScreen> {
     onboardingState = Provider.of(context, listen: false);
 
     unawaited(loadProjectVersion());
+  }
+
+  Future<void> resetOnboarding() async {
+    await onboardingState.reset();
+
+    if (!mounted) return;
+
+    ScaffoldMessenger.of(context).showSnackBar(
+      // TODO: Localize
+      const SnackBar(content: Text('Onboarding state reset')),
+    );
+  }
+
+  void incrementTapCount() {
+    if (tapCount < 5) {
+      tapCount++;
+
+      if (tapCount == 5) {
+        unawaited(resetOnboarding());
+      }
+    }
   }
 
   @override
@@ -140,7 +162,7 @@ class _WelcomeScreenState extends State<WelcomeScreen> {
                 ),
               ),
             ),
-            VersionDisplay(version: projectVersion),
+            VersionDisplay(version: projectVersion, onTap: incrementTapCount),
           ],
         ),
       ),

--- a/apps/ergo4all/lib/welcome/version_display.dart
+++ b/apps/ergo4all/lib/welcome/version_display.dart
@@ -4,13 +4,19 @@ import 'package:fpdart/fpdart.dart';
 /// Displays the apps version if it is known.
 class VersionDisplay extends StatelessWidget {
   ///
-  const VersionDisplay({required this.version, super.key});
+  const VersionDisplay({required this.version, this.onTap, super.key});
 
   /// The apps version if known. Should be a semantic version, such as 1.0.3.
   final Option<String> version;
 
+  /// Callback for when the versions is tapped.
+  final void Function()? onTap;
+
   @override
   Widget build(BuildContext context) {
-    return Text(version.match(() => '...', (it) => 'v$it'));
+    return GestureDetector(
+      onTap: onTap,
+      child: Text(version.match(() => '...', (it) => 'v$it')),
+    );
   }
 }


### PR DESCRIPTION
You can now reset the onboarding state, by tapping the version number on the welcome screen 5 times.