### PR TITLE
feat: improve subject creation screen

### DIFF
--- a/apps/ergo4all/lib/onboarding/user_creation_screen.dart
+++ b/apps/ergo4all/lib/onboarding/user_creation_screen.dart
@@ -66,6 +66,8 @@ class _UserCreationScreenState extends State<UserCreationScreen> {
   Widget build(BuildContext context) {
     final localizations = AppLocalizations.of(context)!;
 
+    final theme = Theme.of(context);
+
     return Scaffold(
       body: SafeArea(
         minimum: const EdgeInsets.symmetric(horizontal: largeSpace),
@@ -106,6 +108,8 @@ class _UserCreationScreenState extends State<UserCreationScreen> {
                       decoration: InputDecoration(
                         hintText:
                             localizations.onboarding_userCreation_input_text,
+                        hintStyle: theme.textTheme.bodyLarge
+                            ?.copyWith(color: Colors.grey),
                         filled: true,
                         fillColor: Colors.blueGrey.shade50,
                         border: OutlineInputBorder(


### PR DESCRIPTION
This is how the screen looks now

<img height="400" alt="image" src="https://github.com/user-attachments/assets/79137e9d-4aec-449d-977a-c8267e8e8489" />

Sadly we can't make the cursor in the text field non-centered without making the text field itself non-centered as well.