### PR TITLE
optimize session choice screen

### DIFF
--- a/apps/ergo4all/lib/session_choice_screen.dart
+++ b/apps/ergo4all/lib/session_choice_screen.dart
@@ -3,13 +3,13 @@ import 'dart:async';
 import 'package:common_ui/theme/colors.dart';
 import 'package:common_ui/theme/styles.dart';
 import 'package:common_ui/widgets/icon_back_button.dart';
-import 'package:ergo4all/common/rula_session.dart';
 import 'package:ergo4all/gen/i18n/app_localizations.dart';
+import 'package:ergo4all/profile/common.dart';
+import 'package:ergo4all/profile/storage/common.dart';
 import 'package:ergo4all/results/screen.dart';
 import 'package:ergo4all/scenario/common.dart';
 import 'package:ergo4all/session_storage/session_storage.dart';
-import 'package:ergo4all/profile/common.dart';
-import 'package:ergo4all/profile/storage/common.dart';
+import 'package:ergo4all/session_storage/src/fs.dart';
 import 'package:fast_immutable_collections/fast_immutable_collections.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
@@ -45,7 +45,7 @@ class _SessionEntry extends StatelessWidget {
 
   static final dateFormat = DateFormat('dd MMM yyyy, HH:mm');
 
-  final RulaSession session;
+  final RulaSessionMeta session;
   final Profile profile;
   final void Function()? onTap;
   final void Function()? onDismissed;
@@ -89,7 +89,7 @@ class _SessionChoiceScreenState extends State<SessionChoiceScreen>
   late final RulaSessionRepository sessionRepository;
   late final ProfileRepo profileRepo;
 
-  List<RulaSession> sessions = List.empty();
+  List<RulaSessionMeta> sessions = List.empty();
   IMap<int, Profile> profilesById = const IMap.empty();
 
   @override
@@ -121,14 +121,21 @@ class _SessionChoiceScreenState extends State<SessionChoiceScreen>
   Widget build(BuildContext context) {
     final localizations = AppLocalizations.of(context)!;
 
-    void goToResultsFor(RulaSession session) {
-      final profile = profilesById[session.profileId];
+    Future<void> goToResultsFor(RulaSessionMeta sessionMeta) async {
+      final profile = profilesById[sessionMeta.profileId];
       assert(profile != null, 'Profile for session must exist');
+
+      final session =
+          await sessionRepository.getByTimestamp(sessionMeta.timestamp);
+      assert(
+        session != null,
+        'Session should exist since we just got it from storage',
+      );
 
       if (!context.mounted) return;
       unawaited(
         Navigator.of(context).pushReplacement(
-          ResultsScreen.makeRoute(session, profile!),
+          ResultsScreen.makeRoute(session!, profile!),
         ),
       );
     }

--- a/apps/ergo4all/lib/session_storage/src/common.dart
+++ b/apps/ergo4all/lib/session_storage/src/common.dart
@@ -1,12 +1,19 @@
 import 'package:ergo4all/common/rula_session.dart';
+import 'package:ergo4all/session_storage/src/fs.dart';
 
 /// Store for [RulaSession] objects.
 abstract class RulaSessionRepository {
   /// Stores a [RulaSession] object.
   Future<void> put(RulaSession session);
 
-  /// Retrieves all stored [RulaSession]s
-  Future<List<RulaSession>> getAll();
+  /// Attempts to load the [RulaSession] associated with the given
+  /// timestamp. If no such session is found `null` is returned.
+  Future<RulaSession?> getByTimestamp(int timestamp);
+
+  /// Retrieves meta data for all stored [RulaSession]s. If you want to
+  /// actually load the full session data use [getByTimestamp] with
+  /// [RulaSessionMeta.timestamp].
+  Future<List<RulaSessionMeta>> getAll();
 
   /// Deletes a [RulaSession] based on it's [timestamp].
   Future<void> deleteByTimestamp(int timestamp);


### PR DESCRIPTION
We now only load session meta-data instead of all the session data on the session choice screen. This is both a speed up and helps keep ram usage down. We now only load the full session data once a session is selected