### PR TITLE
feat: uniform screen bottom margings

### DIFF
--- a/apps/ergo4all/lib/analysis/screen.dart
+++ b/apps/ergo4all/lib/analysis/screen.dart
@@ -435,6 +435,7 @@ class _LiveAnalysisScreenState extends State<LiveAnalysisScreen>
                 child: Text(isRecording ? 'Stop' : 'Start'),
               ),
             ),
+            const SizedBox(height: largeSpace),
           ],
         ),
       ),

--- a/apps/ergo4all/lib/imprint_screen.dart
+++ b/apps/ergo4all/lib/imprint_screen.dart
@@ -70,45 +70,46 @@ class ImprintScreen extends StatelessWidget {
         titleText: localizations.imprint,
         withBackButton: true,
       ),
-      body: Padding(
-        padding: const EdgeInsets.symmetric(
-          horizontal: mediumSpace,
-          vertical: largeSpace,
-        ),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            const _ContactBlock(
-              logo: CustomImages.logoAk,
-              companyName: 'AK Niederösterreich',
-              companyAddress: '[Address]',
-              contactPersonName: '[Contact Name]',
-              contactEmail: '[Contact Email]',
-              contactTelephone: '[Contact Telephone]',
-            ),
-            const SizedBox(height: largeSpace),
-            const _ContactBlock(
-              logo: CustomImages.logoFhStp,
-              companyName: 'FH St. Pölten',
-              companyAddress: 'Campus-Platz 1, A-3100 St. Pölten',
-              contactPersonName: 'Christian Jandl',
-              contactEmail: 'christian.jandl@fhstp.ac.at',
-              contactTelephone: '+43676847228618',
-            ),
-            const SizedBox(height: largeSpace),
-            const _ContactBlock(
-              logo: CustomImages.logoTUWien,
-              companyName: 'TU Wien',
-              companyAddress: 'Theresianumgasse 27, 1040 Wien',
-              contactPersonName: 'David Kostolani',
-              contactEmail: 'david.kostolani@tuwien.ac.at',
-              contactTelephone: '',
-            ),
-            TextButton(
-              onPressed: goToPrivacy,
-              child: Text(localizations.menu_privacy_label),
-            ),
-          ],
+      body: SafeArea(
+        minimum: const EdgeInsets.symmetric(horizontal: mediumSpace),
+        child: SingleChildScrollView(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const SizedBox(height: largeSpace),
+              const _ContactBlock(
+                logo: CustomImages.logoAk,
+                companyName: 'AK Niederösterreich',
+                companyAddress: '[Address]',
+                contactPersonName: '[Contact Name]',
+                contactEmail: '[Contact Email]',
+                contactTelephone: '[Contact Telephone]',
+              ),
+              const SizedBox(height: largeSpace),
+              const _ContactBlock(
+                logo: CustomImages.logoFhStp,
+                companyName: 'FH St. Pölten',
+                companyAddress: 'Campus-Platz 1, A-3100 St. Pölten',
+                contactPersonName: 'Christian Jandl',
+                contactEmail: 'christian.jandl@fhstp.ac.at',
+                contactTelephone: '+43676847228618',
+              ),
+              const SizedBox(height: largeSpace),
+              const _ContactBlock(
+                logo: CustomImages.logoTUWien,
+                companyName: 'TU Wien',
+                companyAddress: 'Theresianumgasse 27, 1040 Wien',
+                contactPersonName: 'David Kostolani',
+                contactEmail: 'david.kostolani@tuwien.ac.at',
+                contactTelephone: '',
+              ),
+              TextButton(
+                onPressed: goToPrivacy,
+                child: Text(localizations.menu_privacy_label),
+              ),
+              const SizedBox(height: largeSpace),
+            ],
+          ),
         ),
       ),
     );

--- a/apps/ergo4all/lib/onboarding/ergonomics_info_screen.dart
+++ b/apps/ergo4all/lib/onboarding/ergonomics_info_screen.dart
@@ -120,17 +120,15 @@ class ErgonomicsInfoScreen extends StatelessWidget {
                 ),
               ),
             ),
-            Padding(
-              padding: const EdgeInsets.only(bottom: largeSpace),
-              child: Center(
-                child: ElevatedButton(
-                  key: const Key('next'),
-                  style: primaryTextButtonStyle,
-                  onPressed: goToUserCreation,
-                  child: Text(localizations.onboarding_label),
-                ),
+            Center(
+              child: ElevatedButton(
+                key: const Key('next'),
+                style: primaryTextButtonStyle,
+                onPressed: goToUserCreation,
+                child: Text(localizations.onboarding_label),
               ),
             ),
+            const SizedBox(height: largeSpace),
           ],
         ),
       ),

--- a/apps/ergo4all/lib/onboarding/pre_intro_screen.dart
+++ b/apps/ergo4all/lib/onboarding/pre_intro_screen.dart
@@ -82,17 +82,15 @@ class PreIntroScreen extends StatelessWidget {
                 ),
               ),
             ),
-            Padding(
-              padding: const EdgeInsets.only(bottom: largeSpace),
-              child: Center(
-                child: ElevatedButton(
-                  key: const Key('next'),
-                  style: primaryTextButtonStyle,
-                  onPressed: goToTermsOfUse,
-                  child: Text(localizations.onboarding_label),
-                ),
+            Center(
+              child: ElevatedButton(
+                key: const Key('next'),
+                style: primaryTextButtonStyle,
+                onPressed: goToTermsOfUse,
+                child: Text(localizations.onboarding_label),
               ),
             ),
+            const SizedBox(height: largeSpace),
           ],
         ),
       ),

--- a/apps/ergo4all/lib/onboarding/privacy_screen.dart
+++ b/apps/ergo4all/lib/onboarding/privacy_screen.dart
@@ -82,17 +82,15 @@ class PrivacyScreen extends StatelessWidget {
                 ),
               ),
             ),
-            Padding(
-              padding: const EdgeInsets.only(bottom: largeSpace),
-              child: Center(
-                child: ElevatedButton(
-                  key: const Key('next'),
-                  style: primaryTextButtonStyle,
-                  onPressed: goToPreIntro,
-                  child: Text(localizations.onboarding_label),
-                ),
+            Center(
+              child: ElevatedButton(
+                key: const Key('next'),
+                style: primaryTextButtonStyle,
+                onPressed: goToPreIntro,
+                child: Text(localizations.onboarding_label),
               ),
             ),
+            const SizedBox(height: largeSpace),
           ],
         ),
       ),

--- a/apps/ergo4all/lib/onboarding/terms_of_use_screen.dart
+++ b/apps/ergo4all/lib/onboarding/terms_of_use_screen.dart
@@ -115,17 +115,15 @@ class _TermsOfUseScreenState extends State<TermsOfUseScreen> {
                 ),
               ],
             ),
-            Padding(
-              padding: const EdgeInsets.only(bottom: largeSpace),
-              child: Center(
-                child: ElevatedButton(
-                  key: const Key('next'),
-                  style: primaryTextButtonStyle,
-                  onPressed: checkBoxValue ? goToErgonomicsInfo : null,
-                  child: Text(localizations.onboarding_label),
-                ),
+            Center(
+              child: ElevatedButton(
+                key: const Key('next'),
+                style: primaryTextButtonStyle,
+                onPressed: checkBoxValue ? goToErgonomicsInfo : null,
+                child: Text(localizations.onboarding_label),
               ),
             ),
+            const SizedBox(height: largeSpace),
           ],
         ),
       ),

--- a/apps/ergo4all/lib/privacy_screen.dart
+++ b/apps/ergo4all/lib/privacy_screen.dart
@@ -47,6 +47,7 @@ class PrivacyScreen extends StatelessWidget {
               style: staticBodyStyle,
               textAlign: TextAlign.center,
             ),
+            const SizedBox(height: largeSpace),
           ],
         ),
       ),

--- a/apps/ergo4all/lib/profile/management_screen.dart
+++ b/apps/ergo4all/lib/profile/management_screen.dart
@@ -208,6 +208,7 @@ class _ProfileManagementScreenState extends State<ProfileManagementScreen> {
               style: primaryTextButtonStyle,
               child: Text(localizations.profile_choice_new),
             ),
+            const SizedBox(height: largeSpace),
           ],
         ),
       ),

--- a/apps/ergo4all/lib/results/body_part_detail/screen.dart
+++ b/apps/ergo4all/lib/results/body_part_detail/screen.dart
@@ -129,6 +129,7 @@ class BodyPartResultsScreen extends StatelessWidget {
             ),
             const SizedBox(height: smallSpace),
             Text(message, style: dynamicBodyStyle),
+            const SizedBox(height: largeSpace),
           ],
         ),
       ),

--- a/apps/ergo4all/lib/results/screen.dart
+++ b/apps/ergo4all/lib/results/screen.dart
@@ -156,6 +156,7 @@ class ResultsScreen extends StatelessWidget {
                   textAlign: TextAlign.center,
                 ),
               ),
+              const SizedBox(height: largeSpace),
             ],
           ),
         ),

--- a/apps/ergo4all/lib/scenario/detail/screen.dart
+++ b/apps/ergo4all/lib/scenario/detail/screen.dart
@@ -153,6 +153,7 @@ class _ScenarioDetailScreenState extends State<ScenarioDetailScreen> {
                           selectedProfile != null ? goToRecordScreen : null,
                       child: Text(localizations.record_label),
                     ),
+                    const SizedBox(height: largeSpace),
                   ],
                 ),
               ),

--- a/apps/ergo4all/lib/scenario/scenario_choice_screen.dart
+++ b/apps/ergo4all/lib/scenario/scenario_choice_screen.dart
@@ -70,6 +70,7 @@ class ScenarioChoiceScreen extends StatelessWidget {
                   ),
                 ),
               ),
+              const SizedBox(height: largeSpace),
             ],
           ),
         ),

--- a/apps/ergo4all/lib/session_choice_screen.dart
+++ b/apps/ergo4all/lib/session_choice_screen.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:common_ui/theme/colors.dart';
+import 'package:common_ui/theme/spacing.dart';
 import 'package:common_ui/theme/styles.dart';
 import 'package:common_ui/widgets/icon_back_button.dart';
 import 'package:ergo4all/gen/i18n/app_localizations.dart';
@@ -171,21 +172,28 @@ class _SessionChoiceScreenState extends State<SessionChoiceScreen>
                   style: paragraphHeaderStyle,
                 ),
               )
-            : ListView.builder(
-                itemCount: sessions.length,
-                itemBuilder: (context, index) {
-                  final session = sessions[index];
-                  return _SessionEntry(
-                    session: session,
-                    profile: profilesById[session.profileId]!,
-                    onDismissed: () {
-                      deleteSessionWith(index);
-                    },
-                    onTap: () {
-                      goToResultsFor(session);
-                    },
-                  );
-                },
+            : Column(
+                children: [
+                  Expanded(
+                    child: ListView.builder(
+                      itemCount: sessions.length,
+                      itemBuilder: (context, index) {
+                        final session = sessions[index];
+                        return _SessionEntry(
+                          session: session,
+                          profile: profilesById[session.profileId]!,
+                          onDismissed: () {
+                            deleteSessionWith(index);
+                          },
+                          onTap: () {
+                            goToResultsFor(session);
+                          },
+                        );
+                      },
+                    ),
+                  ),
+                  const SizedBox(height: largeSpace),
+                ],
               ),
       ),
     );

--- a/apps/ergo4all/lib/tips/tip_choice_screen.dart
+++ b/apps/ergo4all/lib/tips/tip_choice_screen.dart
@@ -78,6 +78,7 @@ class TipChoiceScreen extends StatelessWidget {
                   ),
                 ),
               ),
+              const SizedBox(height: largeSpace),
             ],
           ),
         ),

--- a/apps/ergo4all/lib/welcome/screen.dart
+++ b/apps/ergo4all/lib/welcome/screen.dart
@@ -163,6 +163,7 @@ class _WelcomeScreenState extends State<WelcomeScreen> {
               ),
             ),
             VersionDisplay(version: projectVersion, onTap: incrementTapCount),
+            const SizedBox(height: largeSpace),
           ],
         ),
       ),


### PR DESCRIPTION
All screens now have a uniform minimum bottom margin between their lowest ui elements and the bottom edge of the screen / control buttons.

This prevents the look of buttons "sticking" to the bottom edge

This resolves one of the issues mentioned in #154