### PR TITLE
refactor: freestyle scenario

### DIFF
--- a/apps/ergo4all/lib/analysis/screen.dart
+++ b/apps/ergo4all/lib/analysis/screen.dart
@@ -46,16 +46,20 @@ class LiveAnalysisScreen extends StatefulWidget {
   static const String routeName = 'live-analysis';
 
   /// Creates a [MaterialPageRoute] to navigate to this screen for analyzing
-  /// a [profile] in a [scenario].
-  static MaterialPageRoute<void> makeRoute(Scenario scenario, Profile profile) {
+  /// a [profile] in a [scenario]. A `null` [Scenario] indicates freestyle mode.
+  static MaterialPageRoute<void> makeRoute(
+    Scenario? scenario,
+    Profile profile,
+  ) {
     return MaterialPageRoute(
       builder: (_) => LiveAnalysisScreen(scenario: scenario, profile: profile),
       settings: const RouteSettings(name: routeName),
     );
   }
 
-  /// The scenario for which to make an analysis.
-  final Scenario scenario;
+  /// The scenario for which to make an analysis. `null` indicates freestyle
+  /// mode.
+  final Scenario? scenario;
 
   /// The profile which was used in the recording.
   final Profile profile;
@@ -109,7 +113,7 @@ class _LiveAnalysisScreenState extends State<LiveAnalysisScreen>
   StreamSubscription<Activity>? activitySubscription;
 
   /// Returns true if the current scenario is freestyle mode
-  bool get isFreestyleMode => widget.scenario == Scenario.freestyle;
+  bool get isFreestyleMode => widget.scenario == null;
 
   Future<void> goToResults() async {
     if (!context.mounted) return;

--- a/apps/ergo4all/lib/common/rula_session.dart
+++ b/apps/ergo4all/lib/common/rula_session.dart
@@ -46,8 +46,9 @@ class RulaSession {
   /// Id of the user who was recorded in this session.
   final int profileId;
 
-  /// [Scenario] which was recorded in this session.
-  final Scenario scenario;
+  /// [Scenario] which was recorded in this session, or `null` if it
+  /// was freestyle mode.
+  final Scenario? scenario;
 
   /// The recorded timeline.
   final RulaTimeline timeline;

--- a/apps/ergo4all/lib/results/improvements/page.dart
+++ b/apps/ergo4all/lib/results/improvements/page.dart
@@ -33,11 +33,11 @@ class ImprovementsPage extends StatelessWidget {
     this.mostPopularActivity,
   });
 
-  /// The recorded scenario.
-  final Scenario scenario;
+  /// The recorded scenario or `null` if it was freestyle mode.
+  final Scenario? scenario;
 
   /// Activity for which to display improvements in case the
-  /// [ImprovementsPage.scenario] is [Scenario.freestyle].
+  /// [ImprovementsPage.scenario] is `null`.
   final Activity? mostPopularActivity;
 
   @override
@@ -46,14 +46,16 @@ class ImprovementsPage extends StatelessWidget {
 
     // In freestyle mode, determine tips and improvements based on selected
     // activity
-    final textScenario = scenario == Scenario.freestyle
-        ? (mostPopularActivity != null
-            ? _scenarioFor(mostPopularActivity!) ?? Scenario.freestyle
-            : Scenario.freestyle)
-        : scenario;
+    final textScenario = scenario ??
+        (mostPopularActivity != null
+            ? _scenarioFor(mostPopularActivity!)
+            : null);
 
-    final tips = localizations.scenarioTip(textScenario);
-    final improvements = localizations.scenarioImprovement(textScenario);
+    final tips =
+        textScenario != null ? localizations.scenarioTip(textScenario) : '';
+    final improvements = textScenario != null
+        ? localizations.scenarioImprovement(textScenario)
+        : '';
 
     return SingleChildScrollView(
       child: Column(
@@ -79,9 +81,10 @@ class ImprovementsPage extends StatelessWidget {
             style: dynamicBodyStyle,
             textAlign: TextAlign.left,
           ),
-          Center(
-            child: ScenarioGoodBadGraphic(textScenario, height: 330),
-          ),
+          if (textScenario != null)
+            Center(
+              child: ScenarioGoodBadGraphic(textScenario, height: 330),
+            ),
         ],
       ),
     );

--- a/apps/ergo4all/lib/results/improvements/scenario_good_bad_graphic.dart
+++ b/apps/ergo4all/lib/results/improvements/scenario_good_bad_graphic.dart
@@ -30,7 +30,6 @@ class ScenarioGoodBadGraphic extends StatelessWidget {
       Scenario.conveyorBelt =>
         'standing',
       Scenario.ceiling => 'overhead_work',
-      Scenario.freestyle => null,
     };
 
     final graphicKey =

--- a/apps/ergo4all/lib/results/variable_localizations.dart
+++ b/apps/ergo4all/lib/results/variable_localizations.dart
@@ -47,7 +47,6 @@ extension VariableLocalizations on AppLocalizations {
         Scenario.ceiling => scenario_ceiling_tips,
         Scenario.lift25 => scenario_lift_tips,
         Scenario.conveyorBelt => scenario_conveyor_tips,
-        Scenario.freestyle => '',
       };
 
   /// Gets a localized improvement suggestion for the given [scenario].
@@ -61,6 +60,5 @@ extension VariableLocalizations on AppLocalizations {
         Scenario.ceiling => scenario_ceiling_tools,
         Scenario.lift25 => scenario_lift_tools,
         Scenario.conveyorBelt => scenario_conveyor_tools,
-        Scenario.freestyle => '',
       };
 }

--- a/apps/ergo4all/lib/scenario/common.dart
+++ b/apps/ergo4all/lib/scenario/common.dart
@@ -1,8 +1,5 @@
 /// The different work scenarios we can evaluate
 enum Scenario {
-    /// Freestyle mode with no time limit
-  freestyle,
-
   /// Lifting and carrying heavy loads up to 25 kg
   liftAndCarry,
 
@@ -29,5 +26,4 @@ enum Scenario {
 
   /// Working on a conveyor belt for long periods
   conveyorBelt,
-
 }

--- a/apps/ergo4all/lib/scenario/detail/screen.dart
+++ b/apps/ergo4all/lib/scenario/detail/screen.dart
@@ -26,16 +26,17 @@ class ScenarioDetailScreen extends StatefulWidget {
   static const String routeName = 'scenario-detail';
 
   /// Creates a [MaterialPageRoute] to navigate to this screen in order to
-  /// view the given [scenario].
-  static MaterialPageRoute<void> makeRoute(Scenario scenario) {
+  /// view the given [scenario]. [scenario] can also be `null` for freestyle
+  /// mode.
+  static MaterialPageRoute<void> makeRoute(Scenario? scenario) {
     return MaterialPageRoute(
       builder: (_) => ScenarioDetailScreen(scenario: scenario),
       settings: const RouteSettings(name: routeName),
     );
   }
 
-  /// The scenario for which to view detail.
-  final Scenario scenario;
+  /// The scenario for which to view detail or `null` for freestyle mode.
+  final Scenario? scenario;
 
   @override
   State<ScenarioDetailScreen> createState() => _ScenarioDetailScreenState();
@@ -132,8 +133,8 @@ class _ScenarioDetailScreenState extends State<ScenarioDetailScreen> {
                       style: dynamicBodyStyle,
                     ),
                     const SizedBox(height: mediumSpace),
-                    if (widget.scenario != Scenario.freestyle) ...[
-                      ScenarioGraphic(widget.scenario, height: 330),
+                    if (widget.scenario != null) ...[
+                      ScenarioGraphic(widget.scenario!, height: 330),
                       const SizedBox(height: mediumSpace),
                     ],
                     ProfileSelector(

--- a/apps/ergo4all/lib/scenario/scenario_choice_screen.dart
+++ b/apps/ergo4all/lib/scenario/scenario_choice_screen.dart
@@ -29,8 +29,7 @@ class ScenarioChoiceScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     final localizations = AppLocalizations.of(context)!;
 
-    // Added scenario passing
-    void goToDetailScreen(Scenario scenario) {
+    void goToDetailScreen(Scenario? scenario) {
       unawaited(
         Navigator.of(context).push(ScenarioDetailScreen.makeRoute(scenario)),
       );
@@ -47,11 +46,12 @@ class ScenarioChoiceScreen extends StatelessWidget {
             width: 275,
             child: ListView.separated(
               padding: const EdgeInsets.symmetric(vertical: largeSpace),
-              itemCount: Scenario.values.length,
+              // +1 for the freestyle button
+              itemCount: Scenario.values.length + 1,
               itemBuilder: (ctx, i) {
-                final scenario = Scenario.values[i];
+                final scenario = i == 0 ? null : Scenario.values[i - 1];
                 return ElevatedButton(
-                  key: Key('scenario_button_${scenario.name}'),
+                  key: Key('scenario_button_${scenario?.name ?? 'freestyle'}'),
                   style: paleTextButtonStyle,
                   onPressed: () {
                     goToDetailScreen(scenario);

--- a/apps/ergo4all/lib/scenario/scenario_graphic.dart
+++ b/apps/ergo4all/lib/scenario/scenario_graphic.dart
@@ -30,7 +30,6 @@ class ScenarioGraphic extends StatelessWidget {
       Scenario.conveyorBelt =>
         'standing',
       Scenario.ceiling => 'overhead_work',
-      Scenario.freestyle => null,
     };
 
     final graphicKey = 'assets/images/puppet_scenario/$graphicFileName.svg';

--- a/apps/ergo4all/lib/scenario/variable_localizations.dart
+++ b/apps/ergo4all/lib/scenario/variable_localizations.dart
@@ -4,7 +4,8 @@ import 'package:ergo4all/scenario/common.dart';
 /// Extensions for getting variable localized texts.
 extension VariableLocalizations on AppLocalizations {
   /// Gets the localized label of a [Scenario].
-  String scenarioLabel(Scenario scenario) => switch (scenario) {
+  /// Also accepts `null` for freestyle scenarios.
+  String scenarioLabel(Scenario? scenario) => switch (scenario) {
         Scenario.liftAndCarry => scenario_lift_and_carry_label,
         Scenario.pull => scenario_pull_label,
         Scenario.seated => scenario_seated_label,
@@ -14,11 +15,12 @@ extension VariableLocalizations on AppLocalizations {
         Scenario.ceiling => scenario_ceiling_label,
         Scenario.lift25 => scenario_lift_label,
         Scenario.conveyorBelt => scenario_conveyor_label,
-        Scenario.freestyle => scenario_freestyle_label,
+        null => scenario_freestyle_label,
       };
 
   /// Gets the localized summary of a [Scenario].
-  String scenarioSummary(Scenario scenario) => switch (scenario) {
+  /// Also accepts `null` for freestyle scenarios.
+  String scenarioSummary(Scenario? scenario) => switch (scenario) {
         Scenario.liftAndCarry => scenario_lift_and_carry_summary,
         Scenario.pull => scenario_pull_summary,
         Scenario.seated => scenario_seated_summary,
@@ -28,11 +30,12 @@ extension VariableLocalizations on AppLocalizations {
         Scenario.ceiling => scenario_ceiling_summary,
         Scenario.lift25 => scenario_lift_and_carry_summary,
         Scenario.conveyorBelt => scenario_conveyor_summary,
-        Scenario.freestyle => scenario_freestyle_summary,
+        null => scenario_freestyle_summary,
       };
 
   /// Gets the localized description of a [Scenario].
-  String scenarioDescription(Scenario scenario) => switch (scenario) {
+  /// Also accepts `null` for freestyle scenarios.
+  String scenarioDescription(Scenario? scenario) => switch (scenario) {
         Scenario.liftAndCarry => scenario_lift_and_carry_description,
         Scenario.pull => scenario_pull_description,
         Scenario.seated => scenario_seated_description,
@@ -42,11 +45,12 @@ extension VariableLocalizations on AppLocalizations {
         Scenario.ceiling => scenario_ceiling_description,
         Scenario.lift25 => scenario_lift_description,
         Scenario.conveyorBelt => scenario_conveyor_description,
-        Scenario.freestyle => scenario_freestyle_description,
+        null => scenario_freestyle_description,
       };
 
   /// Gets the localized expectation text for a [Scenario].
-  String scenarioExpectation(Scenario scenario) => switch (scenario) {
+  /// Also accepts `null` for freestyle scenarios.
+  String scenarioExpectation(Scenario? scenario) => switch (scenario) {
         Scenario.liftAndCarry => scenario_lift_and_carry_expectation,
         Scenario.pull => scenario_pull_expectation,
         Scenario.seated => scenario_seated_expectation,
@@ -56,6 +60,6 @@ extension VariableLocalizations on AppLocalizations {
         Scenario.ceiling => scenario_ceiling_expectation,
         Scenario.lift25 => scenario_lift_expectation,
         Scenario.conveyorBelt => scenario_conveyor_expectation,
-        Scenario.freestyle => scenario_freestyle_expectation,
+        null => scenario_freestyle_expectation,
       };
 }

--- a/apps/ergo4all/lib/session_choice_screen.dart
+++ b/apps/ergo4all/lib/session_choice_screen.dart
@@ -67,7 +67,7 @@ class _SessionEntry extends StatelessWidget {
       Scenario.ceiling => localizations.scenario_ceiling_label,
       Scenario.lift25 => localizations.scenario_lift_label,
       Scenario.conveyorBelt => localizations.scenario_conveyor_label,
-      Scenario.freestyle => localizations.scenario_freestyle_label,
+      null => localizations.scenario_freestyle_label,
     };
     final subTitle = '${profile.nickname} - $scenarioLabel';
 

--- a/apps/ergo4all/lib/session_storage/src/fs.dart
+++ b/apps/ergo4all/lib/session_storage/src/fs.dart
@@ -31,7 +31,7 @@ class RulaSessionMeta {
   final int profileId;
 
   /// Mirror of [RulaSession.scenario].
-  final Scenario scenario;
+  final Scenario? scenario;
 }
 
 typedef _ScoreRow = (int, RulaScores, Activity?);
@@ -61,14 +61,15 @@ Future<RulaSessionMeta> _loadMetaFrom(File file) async {
   final scenarioIndex =
       map['scenarioIndex']!.toIntOption.expect('Should parse scenario-index');
 
-  return RulaSessionMeta(timestamp, profileId, Scenario.values[scenarioIndex]);
+  final scenario = scenarioIndex == -1 ? null : Scenario.values[scenarioIndex];
+  return RulaSessionMeta(timestamp, profileId, scenario);
 }
 
 Future<void> _writeMetaTo(RulaSessionMeta meta, File file) async {
   final map = IMap.fromEntries([
     MapEntry('timestamp', meta.timestamp.toString()),
     MapEntry('profileId', meta.profileId.toString()),
-    MapEntry('scenarioIndex', meta.scenario.index.toString()),
+    MapEntry('scenarioIndex', (meta.scenario?.index ?? -1).toString()),
   ]);
   final text = _stringifyKV(map);
   await file.writeAsString(text);


### PR DESCRIPTION
Freestyle sessions are now represented using `null` for the scenario instead of the custom 'freestyle scenario'. This is more correct for domain modelling purposes but also makes it easier to represent logic which should only work for scenario sessions (takes a Scenario) versus logic which also works for freestyle (takes a Scenario?)