### PR TITLE
fix: prevent screen lock during recording

### DIFF
--- a/apps/ergo4all/lib/analysis/screen.dart
+++ b/apps/ergo4all/lib/analysis/screen.dart
@@ -34,6 +34,7 @@ import 'package:pose_transforming/normalization.dart';
 import 'package:pose_vis/pose_vis.dart';
 import 'package:provider/provider.dart';
 import 'package:rula/rula.dart';
+import 'package:wakelock_plus/wakelock_plus.dart';
 
 /// Screen with a camera-view for analyzing live-recorded footage.
 class LiveAnalysisScreen extends StatefulWidget {
@@ -391,6 +392,8 @@ class _LiveAnalysisScreenState extends State<LiveAnalysisScreen>
       upperBound: maxRecordDuration.inSeconds.toDouble(),
       vsync: this,
     );
+
+    unawaited(WakelockPlus.enable());
   }
 
   @override
@@ -398,6 +401,8 @@ class _LiveAnalysisScreenState extends State<LiveAnalysisScreen>
     activitySubscription?.cancel();
     progressAnimationController.dispose();
     cameraController.map((c) => c.dispose());
+    unawaited(WakelockPlus.disable());
+
     super.dispose();
   }
 

--- a/apps/ergo4all/pubspec.yaml
+++ b/apps/ergo4all/pubspec.yaml
@@ -51,6 +51,7 @@ dependencies:
   tflite_flutter: ^0.11.0
   image: ^4.5.4
   url_launcher: ^6.3.0
+  wakelock_plus: ^1.3.3
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -302,6 +302,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.8"
+  dbus:
+    dependency: transitive
+    description:
+      name: dbus
+      sha256: "79e0c23480ff85dc68de79e2cd6334add97e48f7f4865d17686dd6ea81a47e8c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.11"
   dispose_scope:
     dependency: transitive
     description:
@@ -1438,6 +1446,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "14.3.1"
+  wakelock_plus:
+    dependency: transitive
+    description:
+      name: wakelock_plus
+      sha256: "61713aa82b7f85c21c9f4cd0a148abd75f38a74ec645fcb1e446f882c82fd09b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.3"
+  wakelock_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: wakelock_plus_platform_interface
+      sha256: "036deb14cd62f558ca3b73006d52ce049fabcdcb2eddfe0bf0fe4e8a943b5cf2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.0"
   watcher:
     dependency: transitive
     description:


### PR DESCRIPTION
We now use the wakelock_plus package to prevent screen locking while on the analysis screen.